### PR TITLE
fix(public): Resolve runtime error in PublicLayout

### DIFF
--- a/app/(public)/TopBarClient.tsx
+++ b/app/(public)/TopBarClient.tsx
@@ -1,7 +1,0 @@
-"use client";
-import { TopBar } from '../../components/TopBar';
-
-export default function TopBarClient() {
-  return <TopBar />;
-}
-

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TopBarClient from './TopBarClient';
+import { TopBar } from '../../components/TopBar';
 import { SponsorBanner } from '../../components/support/SponsorBanner';
 import { BottomNav } from '../../components/BottomNav';
 import { Footer } from '../../components/Footer';
@@ -15,7 +15,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
   return (
     <div>
       <div>
-        <TopBarClient />
+        <TopBar />
       </div>
       <SponsorBanner />
       <main className="mx-auto max-w-6xl p-6">{children}</main>


### PR DESCRIPTION
The application was throwing a "Cannot read properties of undefined (reading 'call')" error when rendering the `<TopBarClient />` component in the `PublicLayout`.

This was likely due to a module resolution issue with the Next.js app router, caused by having identically named wrapper components in different route groups (`app/(public)` and `app/app`).

The fix involves removing the unnecessary `TopBarClient` wrapper component and using the `TopBar` component directly within `PublicLayout`. This simplifies the component hierarchy and resolves the runtime error.

- Modified `app/(public)/layout.tsx` to import and render `TopBar` directly.
- Deleted the redundant `app/(public)/TopBarClient.tsx` file.