### PR TITLE
fix(public): Resolve runtime error by using path alias for TopBar

### DIFF
--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TopBar } from '../../components/TopBar';
+import { TopBar } from '@components/TopBar';
 import { SponsorBanner } from '../../components/support/SponsorBanner';
 import { BottomNav } from '../../components/BottomNav';
 import { Footer } from '../../components/Footer';


### PR DESCRIPTION
The application was throwing a "Cannot read properties of undefined (reading 'call')" error when rendering the `TopBar` component in the `PublicLayout`.

This was caused by an issue with how Next.js was resolving the relative path to the component.

The fix involves changing the import for the `TopBar` component to use the absolute path alias `@components/TopBar` defined in `tsconfig.json`. This provides a more robust import path and resolves the runtime error.

This change is a follow-up to a previous attempt that also aimed to fix this issue. The initial fix, which involved removing a wrapper component, revealed this deeper path resolution problem.