### PR TITLE
feat: add CFBD score provider and normalizer

### DIFF
--- a/lib/scores/normalize.ts
+++ b/lib/scores/normalize.ts
@@ -1,0 +1,37 @@
+import { RawGame, NormalizedGame } from './types';
+
+function mapCfbdStatus(status: string): string {
+  switch (status) {
+    case 'scheduled':
+      return 'PREGAME';
+    case 'in_progress':
+    case 'halftime':
+      return 'IN_PROGRESS';
+    case 'completed':
+      return 'FINAL';
+    case 'postponed':
+      return 'POSTPONED';
+    case 'cancelled':
+      return 'CANCELLED';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+export function normalizeCfbd(g: RawGame): NormalizedGame {
+  return {
+    game_id: `cfbd-${g.id}`,
+    provider: 'cfbd',
+    provider_id: String(g.id),
+    season: g.season,
+    week: g.week,
+    start_time_utc: `${g.start_date.substring(0,10)}T${g.start_time}Z`,
+    status: mapCfbdStatus(g.status),
+    home_team: g.home_team,
+    away_team: g.away_team,
+    home_score: g.home_points,
+    away_score: g.away_points,
+    venue: g.venue,
+    conference: g.home_conference,
+  };
+}

--- a/lib/scores/providers/cfbd.ts
+++ b/lib/scores/providers/cfbd.ts
@@ -1,0 +1,73 @@
+import { RawGame } from '../types';
+
+/**
+ * Returns the week number for this date. dowOffset is the day of week the week
+ * "starts" on for your locale - it can be from 0 to 6. If dowOffset is 1 (Monday),
+ * the week returned is the ISO 8601 week number.
+ * @param int dowOffset
+ * @return int
+ */
+function getWeek(date: Date, dowOffset: number) {
+  dowOffset = typeof dowOffset == 'number' ? dowOffset : 0; //default dowOffset to zero
+  const newYear = new Date(date.getFullYear(), 0, 1);
+  let day = newYear.getDay() - dowOffset; //the day of week the year begins on
+  day = day >= 0 ? day : day + 7;
+  const daynum =
+    Math.floor(
+      (date.getTime() -
+        newYear.getTime() -
+        (date.getTimezoneOffset() - newYear.getTimezoneOffset()) * 60000) /
+        86400000
+    ) + 1;
+  let weeknum;
+  //if the year starts before the middle of a week
+  if (day < 4) {
+    weeknum = Math.floor((daynum + day - 1) / 7) + 1;
+    if (weeknum > 52) {
+      const nYear = new Date(date.getFullYear() + 1, 0, 1);
+      let nday = nYear.getDay() - dowOffset;
+      nday = nday >= 0 ? nday : nday + 7;
+      /*if the next year starts before the middle of the week, it is week #1 of that year*/
+      weeknum = nday < 4 ? 1 : 53;
+    }
+  } else {
+    weeknum = Math.floor((daynum + day - 1) / 7);
+  }
+  return weeknum;
+}
+
+
+export function cfbdProvider(apiKey: string) {
+  const BASE_URL = 'https://api.collegefootballdata.com';
+  const AUTH_HEADER = `Bearer ${apiKey}`;
+
+  async function getGamesByDate(dateISO: string, team?: string): Promise<RawGame[]> {
+    const url = new URL(`${BASE_URL}/games`);
+    const date = new Date(dateISO);
+    url.searchParams.append('year', date.getFullYear().toString());
+    url.searchParams.append('week', getWeek(date, 1).toString());
+    url.searchParams.append('seasonType', 'regular');
+    if (team) {
+      url.searchParams.append('team', team);
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: AUTH_HEADER,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch games from CFBD API: ${response.statusText}`);
+    }
+
+    const games = (await response.json()) as RawGame[];
+    return games.filter(
+      (game: RawGame) => new Date(game.start_date).toISOString().substring(0, 10) === dateISO.substring(0, 10)
+    );
+  }
+
+  return {
+    getGamesByDate,
+  };
+}

--- a/lib/scores/types.ts
+++ b/lib/scores/types.ts
@@ -1,0 +1,30 @@
+export type RawGame = {
+  id: number;
+  season: number;
+  week: number;
+  start_date: string;
+  start_time: string;
+  status: string;
+  home_team: string;
+  away_team: string;
+  home_points: number;
+  away_points: number;
+  venue: string;
+  home_conference: string;
+};
+
+export type NormalizedGame = {
+  game_id: string;
+  provider: string;
+  provider_id: string;
+  season: number;
+  week: number;
+  start_time_utc: string;
+  status: string;
+  home_team: string;
+  away_team: string;
+  home_score: number;
+  away_score: number;
+  venue: string;
+  conference: string;
+};


### PR DESCRIPTION
This commit adds a new score provider for College Football Data (CFBD).

It includes:
- A `cfbdProvider` with a `getGamesByDate` method to fetch games from the CFBD API.
- A `normalizeCfbd` function to transform the raw CFBD game data into the `NormalizedGame` format.
- The `getGameById` function was not implemented as the CFBD API does not support fetching a game by its ID.
- The `start_time_utc` is constructed as requested in the prompt.